### PR TITLE
Fix printing of immediate operands in TAC printer

### DIFF
--- a/middle/src/tac_printer.rs
+++ b/middle/src/tac_printer.rs
@@ -51,11 +51,13 @@ pub fn print_ir(instructions: &Vec<IRInstruction>) -> String {
                     _ => unreachable!(),
                 };
                 if let (IRValue::TempReg(left), IRValue::TempReg(right), IRValue::TempReg(result)) =
-                    (&instr.operands[0], &instr.operands[1], &instr.operands[2]) {
+                    (&instr.operands[0], &instr.operands[1], &instr.operands[2])
+                {
                     format!(" _t{} = _t{} {} _t{};", result, left, symbol, right)
                 } else if let (IRValue::TempReg(left), IRValue::Number(num), IRValue::TempReg(result)) =
-                    (&instr.operands[0], &instr.operands[1], &instr.operands[2]) {
-                    format!(" _t{} = _t{} {} _t{};", result, left, symbol, num)
+                    (&instr.operands[0], &instr.operands[1], &instr.operands[2])
+                {
+                    format!(" _t{} = _t{} {} {};", result, left, symbol, num)
                 }
                 else {
                     format!("Expected three TempRegs for {}", op)
@@ -84,9 +86,9 @@ pub fn print_ir(instructions: &Vec<IRInstruction>) -> String {
             },
             Opcode::BranchIfFalse => {
                 if let (IRValue::TempReg(cond), IRValue::Label(label)) = (&instr.operands[0], &instr.operands[1]) {
-                    format!(" BranchIfFasle _t{} L{};", cond, label)
+                    format!(" BranchIfFalse _t{} L{};", cond, label)
                 } else {
-                    format!("Expected TempReg and Label for BranchIfTrue")
+                    format!("Expected TempReg and Label for BranchIfFalse")
                 }
             },
             Opcode::JumpIfZero => {


### PR DESCRIPTION
## Summary
- fix constant operand formatting in TAC printer
- correct typo in BranchIfFalse output

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683f404b0c44832588b181ff670528e6